### PR TITLE
Small Tweak for GCC 10.0+ Build

### DIFF
--- a/src/numbers.c
+++ b/src/numbers.c
@@ -680,7 +680,7 @@ bf_random(Var arglist, Byte next, void *vdata, Objid progr)
 
 int mels_random()
 {
-   extern FILE *Dev_Random;
+   FILE *Dev_Random;
    int result;
    char buf[5]; 
    /* read 4 bytes from /dev/urandom */

--- a/src/server.c
+++ b/src/server.c
@@ -440,7 +440,7 @@ main_loop(void)
     /* Open /dev/urandom and keep it open as long as the server is running
        so that our random() has a source of random bits.  Dev_Random is
        defined globally in server.h */
-    extern FILE *Dev_Random;
+    FILE *Dev_Random;
     Dev_Random = fopen("/dev/urandom", "r");
     if (Dev_Random == NULL) panic("Couldn't open /dev/urandom");
 

--- a/src/server.h
+++ b/src/server.h
@@ -161,7 +161,7 @@ extern void boot_player(Objid player);
 extern void write_active_connections(void);
 extern int read_active_connections(void);
 
-FILE  *Dev_Random;  /* Global file pointer for /dev/random */
+extern FILE  *Dev_Random;  /* Global file pointer for /dev/random */
 
 #endif				/* Server_H */
 


### PR DESCRIPTION
GCC versions above 10.0 use -fno-common instead of -fcommon. The change in default operation for GCC 10 prevented the project from building because of how the Dev_Random file pointer was defined, as it was being defined multiple times per the compiler.